### PR TITLE
[FE] 라벨 페이지 UI 구현

### DIFF
--- a/FE/issue-tracker/src/App.tsx
+++ b/FE/issue-tracker/src/App.tsx
@@ -7,7 +7,7 @@ import Login from '@pages/Login';
 import Issues from '@pages/Issues';
 import NewIssue from '@pages/NewIssue';
 import Labels from '@pages/Labels';
-import MileStones from '@pages/MileStones';
+import Milestones from '@pages/Milestones';
 import IssueDetail from '@pages/IssueDetail';
 
 function App() {
@@ -32,7 +32,7 @@ function App() {
               <Labels />
             </Route>
             <Route path="/milestones">
-              <MileStones />
+              <Milestones />
             </Route>
           </Switch>
         </BrowserRouter>

--- a/FE/issue-tracker/src/assets/cancel.svg
+++ b/FE/issue-tracker/src/assets/cancel.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.2999 4.70023L4.70025 11.2999M4.7002 4.70016L11.2999 11.2998" stroke="#111111" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/FE/issue-tracker/src/assets/refresh.svg
+++ b/FE/issue-tracker/src/assets/refresh.svg
@@ -1,0 +1,12 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<path d="M0.666748 2.66666V6.66666H4.66675" stroke="#14142B" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.3333 13.3333V9.33334H11.3333" stroke="#14142B" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.6601 6.00001C13.322 5.04453 12.7473 4.19028 11.9898 3.51696C11.2322 2.84363 10.3164 2.37319 9.32789 2.14952C8.33934 1.92584 7.31024 1.95624 6.33662 2.23786C5.363 2.51948 4.47658 3.04315 3.76008 3.76001L0.666748 6.66668M15.3334 9.33334L12.2401 12.24C11.5236 12.9569 10.6372 13.4805 9.66354 13.7622C8.68992 14.0438 7.66082 14.0742 6.67227 13.8505C5.68372 13.6268 4.76795 13.1564 4.01039 12.4831C3.25284 11.8097 2.67819 10.9555 2.34008 10" stroke="#14142B" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/FE/issue-tracker/src/components/common/Actions.tsx
+++ b/FE/issue-tracker/src/components/common/Actions.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import Tabs from '@components/common/Tabs';
+import { Button } from '@chakra-ui/react';
+
+interface Props {
+  page: string;
+}
+
+function Actions({ page }: Props) {
+  return (
+    <ActionsWrap>
+      <Tabs page={page} />
+      <Button
+        width="120px"
+        fontSize="xs"
+        background="bl_initial"
+        colorScheme="blue"
+      >
+        + 추가
+      </Button>
+    </ActionsWrap>
+  );
+}
+
+export default Actions;
+
+const ActionsWrap = styled.section`
+  /* theme에 추가하기 */
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+`;

--- a/FE/issue-tracker/src/components/common/Header.tsx
+++ b/FE/issue-tracker/src/components/common/Header.tsx
@@ -16,6 +16,7 @@ export default Header;
 const HeaderContainer = styled.div`
   width: 100%;
   height: 94px;
+  margin-bottom: 32px;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/FE/issue-tracker/src/components/labels/Actions.tsx
+++ b/FE/issue-tracker/src/components/labels/Actions.tsx
@@ -26,7 +26,8 @@ export default Actions;
 
 const ActionsWrap = styled.section`
   /* theme에 추가하기 */
-  display: flex;
   width: 100%;
+  margin-bottom: 24px;
+  display: flex;
   justify-content: space-between;
 `;

--- a/FE/issue-tracker/src/components/labels/Label.tsx
+++ b/FE/issue-tracker/src/components/labels/Label.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+interface Props {
+  name: string;
+  colorCode: string;
+  fontLight: boolean;
+}
+
+function Label({ name, colorCode, fontLight }: Props) {
+  return (
+    <LabelTag colorCode={colorCode} fontLight={fontLight}>
+      {name}
+    </LabelTag>
+  );
+}
+
+export default Label;
+
+interface LabelTagType {
+  colorCode: string;
+  fontLight: boolean;
+}
+
+const LabelTag = styled.span<LabelTagType>`
+  padding: 4px 16px;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  border-radius: 30px;
+  cursor: pointer;
+  background-color: ${({ colorCode }) => colorCode};
+  color: ${({ fontLight, theme }) =>
+    fontLight ? theme.colors.gr_offWhite : theme.colors.gr_titleActive};
+`;

--- a/FE/issue-tracker/src/components/labels/LabelInputBox.tsx
+++ b/FE/issue-tracker/src/components/labels/LabelInputBox.tsx
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+import {
+  Input,
+  InputGroup,
+  InputLeftAddon,
+  InputRightAddon,
+  Checkbox,
+} from '@chakra-ui/react';
+import { ReactComponent as Refresh } from '@assets/refresh.svg';
+import Label from '@components/labels/Label';
+import {
+  labelNameInput,
+  labelDescInput,
+  labelColorLeft,
+  labelCheckbox,
+} from '@components/labels/newLabelStyle';
+
+interface Props {
+  children: JSX.Element;
+}
+
+function LabelInputBox({ children }: Props) {
+  const colorCode = '#EFF0F6';
+
+  return (
+    <NewLabelContent>
+      <LabelTagBox>
+        <Label name={'레이블 이름'} colorCode={colorCode} fontLight={false} />
+      </LabelTagBox>
+
+      <LabelInputsWrap>
+        <Input {...labelNameInput} />
+        <Input {...labelDescInput} />
+
+        <LabelColorInput>
+          <InputGroup size="md" width="240px" marginRight="16px">
+            <InputLeftAddon {...labelColorLeft} children="배경 색상" />
+            <Input value={colorCode} variant="filled" />
+            <InputRightAddon
+              children={<Refresh className="icon_refresh" />}
+              border="none"
+            />
+          </InputGroup>
+          <InputGroup size="md" width="352px" variant="filled">
+            <InputLeftAddon {...labelColorLeft} children="텍스트 색상" />
+            <Checkbox {...labelCheckbox} defaultIsChecked>
+              어두운색
+            </Checkbox>
+            <Checkbox {...labelCheckbox}>밝은색</Checkbox>
+            <InputRightAddon border="none" />
+          </InputGroup>
+        </LabelColorInput>
+        {children}
+      </LabelInputsWrap>
+    </NewLabelContent>
+  );
+}
+
+export default LabelInputBox;
+
+const NewLabelContent = styled.div`
+  display: flex;
+`;
+const LabelTagBox = styled.div`
+  width: 330px;
+  ${({ theme }) => theme.flexCenter};
+`;
+const LabelInputsWrap = styled.div`
+  width: 100%;
+`;
+const LabelColorInput = styled.div`
+  display: flex;
+  .icon_refresh {
+    path {
+      stroke: ${({ theme }) => theme.colors.gr_label};
+    }
+  }
+`;

--- a/FE/issue-tracker/src/components/labels/NewLabel.tsx
+++ b/FE/issue-tracker/src/components/labels/NewLabel.tsx
@@ -1,0 +1,89 @@
+import styled from 'styled-components';
+import {
+  Input,
+  InputGroup,
+  InputLeftAddon,
+  InputRightAddon,
+  Checkbox,
+} from '@chakra-ui/react';
+import { ReactComponent as Refresh } from '@assets/refresh.svg';
+import Label from '@components/labels/Label';
+import {
+  labelNameInput,
+  labelDescInput,
+  labelColorLeft,
+  labelCheckbox,
+} from '@components/labels/newLabelStyle';
+
+function NewLabel() {
+  const colorCode = '#EFF0F6';
+
+  return (
+    <NewLabelWrap>
+      <h2>새로운 레이블 추가</h2>
+
+      <NewLabelContent>
+        <LabelTagBox>
+          <Label name={'레이블 이름'} colorCode={colorCode} fontLight={false} />
+        </LabelTagBox>
+
+        <LabelInputBox>
+          <Input {...labelNameInput} />
+          <Input {...labelDescInput} />
+
+          <LabelColorInput>
+            <InputGroup size="md" width="240px" marginRight="16px">
+              <InputLeftAddon {...labelColorLeft} children="배경 색상" />
+              <Input value={colorCode} variant="filled" />
+              <InputRightAddon
+                children={<Refresh className="icon_refresh" />}
+                border="none"
+              />
+            </InputGroup>
+            <InputGroup size="md" width="352px" variant="filled">
+              <InputLeftAddon {...labelColorLeft} children="텍스트 색상" />
+              <Checkbox {...labelCheckbox} defaultIsChecked>
+                어두운색
+              </Checkbox>
+              <Checkbox {...labelCheckbox}>밝은색</Checkbox>
+              <InputRightAddon border="none" />
+            </InputGroup>
+          </LabelColorInput>
+        </LabelInputBox>
+      </NewLabelContent>
+    </NewLabelWrap>
+  );
+}
+
+export default NewLabel;
+
+const NewLabelWrap = styled.section`
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.gr_line};
+  padding: 32px;
+  border-radius: ${({ theme }) => theme.radii['2xl']};
+  background-color: ${({ theme }) => theme.colors.gr_offWhite};
+  h2 {
+    font-size: ${({ theme }) => theme.fontSizes['2xl']};
+    margin-bottom: 16px;
+  }
+`;
+
+const NewLabelContent = styled.div`
+  display: flex;
+`;
+const LabelTagBox = styled.div`
+  width: 330px;
+  ${({ theme }) => theme.flexCenter};
+`;
+const LabelInputBox = styled.div`
+  width: 100%;
+`;
+const LabelColorInput = styled.div`
+  display: flex;
+  .icon_refresh {
+    path {
+      stroke: ${({ theme }) => theme.colors.gr_label};
+    }
+  }
+`;

--- a/FE/issue-tracker/src/components/labels/NewLabel.tsx
+++ b/FE/issue-tracker/src/components/labels/NewLabel.tsx
@@ -1,56 +1,17 @@
 import styled from 'styled-components';
-import {
-  Input,
-  InputGroup,
-  InputLeftAddon,
-  InputRightAddon,
-  Checkbox,
-} from '@chakra-ui/react';
-import { ReactComponent as Refresh } from '@assets/refresh.svg';
-import Label from '@components/labels/Label';
-import {
-  labelNameInput,
-  labelDescInput,
-  labelColorLeft,
-  labelCheckbox,
-} from '@components/labels/newLabelStyle';
+import { Button } from '@chakra-ui/react';
+import LabelInputBox from '@components/labels/LabelInputBox';
+import { submitButton } from '@components/labels/newLabelStyle';
 
 function NewLabel() {
-  const colorCode = '#EFF0F6';
-
   return (
     <NewLabelWrap>
       <h2>새로운 레이블 추가</h2>
-
-      <NewLabelContent>
-        <LabelTagBox>
-          <Label name={'레이블 이름'} colorCode={colorCode} fontLight={false} />
-        </LabelTagBox>
-
-        <LabelInputBox>
-          <Input {...labelNameInput} />
-          <Input {...labelDescInput} />
-
-          <LabelColorInput>
-            <InputGroup size="md" width="240px" marginRight="16px">
-              <InputLeftAddon {...labelColorLeft} children="배경 색상" />
-              <Input value={colorCode} variant="filled" />
-              <InputRightAddon
-                children={<Refresh className="icon_refresh" />}
-                border="none"
-              />
-            </InputGroup>
-            <InputGroup size="md" width="352px" variant="filled">
-              <InputLeftAddon {...labelColorLeft} children="텍스트 색상" />
-              <Checkbox {...labelCheckbox} defaultIsChecked>
-                어두운색
-              </Checkbox>
-              <Checkbox {...labelCheckbox}>밝은색</Checkbox>
-              <InputRightAddon border="none" />
-            </InputGroup>
-          </LabelColorInput>
-        </LabelInputBox>
-      </NewLabelContent>
+      <LabelInputBox>
+        <ButtonBox>
+          <Button {...submitButton}>+ 완료</Button>
+        </ButtonBox>
+      </LabelInputBox>
     </NewLabelWrap>
   );
 }
@@ -69,21 +30,7 @@ const NewLabelWrap = styled.section`
   }
 `;
 
-const NewLabelContent = styled.div`
+const ButtonBox = styled.div`
   display: flex;
-`;
-const LabelTagBox = styled.div`
-  width: 330px;
-  ${({ theme }) => theme.flexCenter};
-`;
-const LabelInputBox = styled.div`
-  width: 100%;
-`;
-const LabelColorInput = styled.div`
-  display: flex;
-  .icon_refresh {
-    path {
-      stroke: ${({ theme }) => theme.colors.gr_label};
-    }
-  }
+  flex-direction: row-reverse;
 `;

--- a/FE/issue-tracker/src/components/labels/newLabelStyle.ts
+++ b/FE/issue-tracker/src/components/labels/newLabelStyle.ts
@@ -16,6 +16,7 @@ const labelColorLeft = {
   color: 'gray.600',
   fontSize: 'xs',
   border: 'none',
+  marginBottom: '16px',
 };
 
 const labelCheckbox = {
@@ -23,6 +24,30 @@ const labelCheckbox = {
   paddingRight: '16px',
   spacing: '0.8rem',
   colorScheme: 'cyan',
+  marginBottom: '16px',
 };
 
-export { labelNameInput, labelDescInput, labelColorLeft, labelCheckbox };
+const submitButton = {
+  width: '120px',
+  fontSize: 'xs',
+  background: 'bl_initial',
+  colorScheme: 'blue',
+  color: 'white',
+};
+
+const whiteButton = {
+  width: '120px',
+  fontSize: 'xs',
+  background: 'white',
+  color: 'bl_initial',
+  border: '2px solid #007AFF',
+};
+
+export {
+  labelNameInput,
+  labelDescInput,
+  labelColorLeft,
+  labelCheckbox,
+  submitButton,
+  whiteButton,
+};

--- a/FE/issue-tracker/src/components/labels/newLabelStyle.ts
+++ b/FE/issue-tracker/src/components/labels/newLabelStyle.ts
@@ -1,0 +1,28 @@
+const labelNameInput = {
+  placeholder: '레이블 이름',
+  size: 'md',
+  variant: 'filled',
+  marginBottom: '16px',
+};
+
+const labelDescInput = {
+  placeholder: '설명(선택)',
+  size: 'md',
+  variant: 'filled',
+  marginBottom: '16px',
+};
+
+const labelColorLeft = {
+  color: 'gray.600',
+  fontSize: 'xs',
+  border: 'none',
+};
+
+const labelCheckbox = {
+  backgroundColor: '#EDF2F7',
+  paddingRight: '16px',
+  spacing: '0.8rem',
+  colorScheme: 'cyan',
+};
+
+export { labelNameInput, labelDescInput, labelColorLeft, labelCheckbox };

--- a/FE/issue-tracker/src/components/labels/table/EditLabel.tsx
+++ b/FE/issue-tracker/src/components/labels/table/EditLabel.tsx
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+import { Button } from '@chakra-ui/react';
+import { ReactComponent as Edit } from '@assets/edit.svg';
+import { ReactComponent as Cancel } from '@assets/cancel.svg';
+import LabelInputBox from '@components/labels/LabelInputBox';
+import { submitButton, whiteButton } from '@components/labels/newLabelStyle';
+
+function EditLabel() {
+  return (
+    <EditLabelWrap>
+      <h2>레이블 편집</h2>
+      <LabelInputBox>
+        <ButtonBox>
+          <Button {...submitButton}>
+            <Edit className="icon_edit" />
+            완료
+          </Button>
+          <Button {...whiteButton} marginRight="8px">
+            <Cancel className="icon_cancel" />
+            취소
+          </Button>
+        </ButtonBox>
+      </LabelInputBox>
+    </EditLabelWrap>
+  );
+}
+
+export default EditLabel;
+
+const EditLabelWrap = styled.section`
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.gr_line};
+  border-top: none;
+  padding: 32px;
+  background-color: ${({ theme }) => theme.colors.gr_offWhite};
+  h2 {
+    font-size: ${({ theme }) => theme.fontSizes['2xl']};
+    margin-bottom: 16px;
+  }
+  .icon_edit {
+    margin-right: 5px;
+    path {
+      stroke: ${({ theme }) => theme.colors.gr_offWhite};
+    }
+  }
+  .icon_cancel {
+    margin-right: 5px;
+    path {
+      stroke: ${({ theme }) => theme.colors.bl_initial};
+    }
+  }
+`;
+
+const ButtonBox = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+`;

--- a/FE/issue-tracker/src/components/labels/table/LabelCell.tsx
+++ b/FE/issue-tracker/src/components/labels/table/LabelCell.tsx
@@ -1,0 +1,96 @@
+import styled from 'styled-components';
+import { ReactComponent as Edit } from '@assets/edit.svg';
+import { ReactComponent as Delete } from '@assets/trash.svg';
+import Label from '@components/labels/Label';
+
+interface Props {
+  last: boolean;
+}
+
+function LabelCell({ last }: Props) {
+  return (
+    <LabelWrap last={last}>
+      <StyledDiv>
+        <LabelBox>
+          <Label name="documentation" colorCode="#004DE3" fontLight={true} />
+        </LabelBox>
+        <LabelDescript>레이블에 대한 설명</LabelDescript>
+      </StyledDiv>
+
+      <LabelButtons>
+        <EditButton>
+          <Edit className="btn_edit" />
+          <span>편집</span>
+        </EditButton>
+        <DeleteButton>
+          <Delete className="btn_delete" />
+          <span>삭제</span>
+        </DeleteButton>
+      </LabelButtons>
+    </LabelWrap>
+  );
+}
+
+export default LabelCell;
+
+interface LabelWrapType {
+  last: boolean;
+}
+
+const LabelWrap = styled.div<LabelWrapType>`
+  width: 100%;
+  height: 100px;
+  padding: 0 32px;
+  background-color: ${({ theme }) => theme.colors.gr_offWhite};
+  border: 1px solid ${({ theme }) => theme.colors.gr_line};
+  border-top: none;
+  border-radius: ${({ last }) => (last ? '0 0 16px 16px' : 'none')};
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const StyledDiv = styled.div`
+  display: flex;
+`;
+
+const LabelBox = styled.div`
+  width: 208px;
+`;
+
+const LabelDescript = styled.div`
+  width: 800px;
+  color: ${({ theme }) => theme.colors.gr_label};
+`;
+
+const LabelButtons = styled.div`
+  width: 110px;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const EditButton = styled.div`
+  width: 43px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.gr_label};
+  cursor: pointer;
+  .btn_edit > path {
+    stroke: ${({ theme }) => theme.colors.gr_label};
+  }
+`;
+const DeleteButton = styled.div`
+  width: 43px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.error_primary};
+  cursor: pointer;
+  .btn_delete > path {
+    stroke: ${({ theme }) => theme.colors.error_primary};
+  }
+`;

--- a/FE/issue-tracker/src/components/labels/table/LabelTable.tsx
+++ b/FE/issue-tracker/src/components/labels/table/LabelTable.tsx
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
 import TableHeader from '@components/labels/table/TableHeader';
 import LabelCell from '@components/labels/table/LabelCell';
+import EditLabel from '@components/labels/table/EditLabel';
 
 function LabelTable() {
   return (
     <LabelTableWrap>
       <TableHeader />
       <LabelCell last={false} />
+      <EditLabel />
       <LabelCell last={true} />
     </LabelTableWrap>
   );

--- a/FE/issue-tracker/src/components/labels/table/LabelTable.tsx
+++ b/FE/issue-tracker/src/components/labels/table/LabelTable.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import TableHeader from '@components/labels/table/TableHeader';
+import LabelCell from '@components/labels/table/LabelCell';
+
+function LabelTable() {
+  return (
+    <LabelTableWrap>
+      <TableHeader />
+      <LabelCell last={false} />
+      <LabelCell last={true} />
+    </LabelTableWrap>
+  );
+}
+
+export default LabelTable;
+
+const LabelTableWrap = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;

--- a/FE/issue-tracker/src/components/labels/table/TableHeader.tsx
+++ b/FE/issue-tracker/src/components/labels/table/TableHeader.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+function TableHeader() {
+  return <TableHeaderWrap>3개의 레이블</TableHeaderWrap>;
+}
+
+export default TableHeader;
+
+const TableHeaderWrap = styled.div`
+  /* theme에 추가하기 */
+  margin-top: 24px;
+  padding: 18px 30px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 64px;
+  background: ${({ theme }) => theme.colors.gr_background};
+  border: 1px solid ${({ theme }) => theme.colors.gr_line};
+  border-radius: 16px 16px 0px 0px;
+
+  color: ${({ theme }) => theme.colors.gr_label};
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+`;

--- a/FE/issue-tracker/src/pages/Labels.tsx
+++ b/FE/issue-tracker/src/pages/Labels.tsx
@@ -1,12 +1,16 @@
 import styled from 'styled-components';
 import Header from '@components/common/Header';
-import Tabs from '@components/common/Tabs';
+import Actions from '@components/labels/Actions';
+import NewLabel from '@components/labels/NewLabel';
+import LabelTable from '@components/labels/table/LabelTable';
 
 function Labels() {
   return (
     <LabelsPageContainer>
       <Header />
-      <Tabs page="labels" />
+      <Actions page="labels" />
+      <NewLabel />
+      <LabelTable />
     </LabelsPageContainer>
   );
 }
@@ -15,5 +19,4 @@ export default Labels;
 
 const LabelsPageContainer = styled.div`
   ${({ theme }) => theme.page}
-  outline: 1px solid red;
 `;


### PR DESCRIPTION
🚨 충돌이 발생했는데 원인을 파악해서 해결할 예정입니다ㅠㅠ
    (→ 원인은 Milestones 파일명 변경에 따른 충돌이었습니다)

라벨 페이지의 라벨 목록, 라벨 생성, 라벨 편집 UI 완료 되었고,
마일스톤 페이지는 거의 비슷하기 때문에 라벨 페이지보다는 빠르게 완성할 수 있을 것 같습니다!

라벨 생성, 라벨 편집 컴포넌트의 Input이 같기 때문에 LabelInputBox 컴포넌트를 재사용했습니다.
버튼요소에 차이점이 있어 children Props를 사용했습니다.🙂