### PR TITLE
[FE] 이슈 생성 페이지 구현 완료

### DIFF
--- a/FE/issue-tracker/src/components/newIssue/ButtonBox.tsx
+++ b/FE/issue-tracker/src/components/newIssue/ButtonBox.tsx
@@ -1,13 +1,45 @@
+import { useEffect } from 'react';
 import styled from 'styled-components';
-import { useRecoilValue } from 'recoil';
+import { useHistory } from 'react-router-dom';
+import { useRecoilValue, useRecoilState } from 'recoil';
 
 import { Link } from 'react-router-dom';
 import { Button } from '@chakra-ui/button';
 import { ReactComponent as CancelIcon } from '@assets/cancel.svg';
-import { isInputtedTitleState } from '@store/atoms/newIssue';
+import { baseURL } from '@const/var';
+import { fetchWithAuth } from '@utils/fetchWithAuth';
+import {
+  isInputtedTitleAtom,
+  isClickedCompleteBtnAtom,
+  newIssueContentsAtom,
+} from '@store/atoms/newIssue';
+import { getNewIssueBody } from '@store/selectors/newIssue';
 
 function ButtonBox() {
-  const isInputtedTitle = useRecoilValue(isInputtedTitleState);
+  const isInputtedTitle = useRecoilValue(isInputtedTitleAtom);
+  const newIssueContents = useRecoilValue(newIssueContentsAtom);
+  const newIssueHeaderBody = useRecoilValue(getNewIssueBody);
+  const [isClickedCompleteBtn, setIsClickedCompleteBtn] = useRecoilState(
+    isClickedCompleteBtnAtom
+  );
+  const history = useHistory();
+
+  const handleClickComplete = () => setIsClickedCompleteBtn(true);
+
+  useEffect(() => {
+    if (!isClickedCompleteBtn) return;
+    const header = newIssueHeaderBody;
+    const postIssue = async () => {
+      try {
+        await fetchWithAuth(`${baseURL}/issues`, '🤯이슈 생성 에러', header);
+        history.push('/issues');
+        setIsClickedCompleteBtn(false);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    postIssue();
+  }, [newIssueContents]);
 
   return (
     <ButtonBoxWrap>
@@ -18,7 +50,9 @@ function ButtonBox() {
         </CancelBtn>
       </Link>
       {isInputtedTitle ? (
-        <Button {...CompleteBtnStyle}>완료</Button>
+        <Button {...CompleteBtnStyle} onClick={handleClickComplete}>
+          완료
+        </Button>
       ) : (
         <Button {...CompleteBtnStyle} opacity=".4" isDisabled>
           완료

--- a/FE/issue-tracker/src/components/newIssue/ContentsTextArea.tsx
+++ b/FE/issue-tracker/src/components/newIssue/ContentsTextArea.tsx
@@ -1,0 +1,55 @@
+import { useState, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { Textarea } from '@chakra-ui/textarea';
+
+import {
+  isClickedCompleteBtnAtom,
+  newIssueContentsAtom,
+} from '@store/atoms/newIssue';
+import { contentsInputStyle } from './style';
+
+function ContentsTextArea() {
+  const [numOfChars, setNumOfChars] = useState(0);
+  const isClickedCompleteBtn = useRecoilValue(isClickedCompleteBtnAtom);
+  const [newIssueContents, setNewIssueContents] =
+    useRecoilState(newIssueContentsAtom);
+  const contentsInput = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isClickedCompleteBtn && contentsInput.current != null)
+      setNewIssueContents({
+        ...newIssueContents,
+        description: contentsInput.current.value,
+      });
+  }, [isClickedCompleteBtn]);
+
+  const handleChangeTextArea = (e: React.ChangeEvent) => {
+    const target = e.target as HTMLInputElement;
+    const length = target.value.length;
+    if (numOfChars === length) return;
+    setNumOfChars(length);
+  };
+
+  return (
+    <>
+      <Textarea
+        {...contentsInputStyle}
+        ref={contentsInput}
+        onChange={handleChangeTextArea}
+      />
+      <Span>띄어쓰기 포함 {numOfChars} 자</Span>
+    </>
+  );
+}
+
+export default ContentsTextArea;
+
+const Span = styled.div`
+  right: 30px;
+  bottom: 72px;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-weight: ${({ theme }) => theme.fontWeights.medium};
+  color: ${({ theme }) => theme.colors.label};
+  position: absolute;
+`;

--- a/FE/issue-tracker/src/components/newIssue/TextBox.tsx
+++ b/FE/issue-tracker/src/components/newIssue/TextBox.tsx
@@ -1,16 +1,40 @@
+import { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { Input } from '@chakra-ui/input';
 import { Textarea } from '@chakra-ui/textarea';
 
 import { ReactComponent as FileIcon } from '@assets/file.svg';
-import { contentsInput, titleInput } from './style';
-import { isInputtedTitleState } from '@store/atoms/newIssue';
+import { contentsInputStyle, titleInputStyle } from './style';
+import {
+  isInputtedTitleAtom,
+  isClickedCompleteBtnAtom,
+  newIssueContentsAtom,
+} from '@store/atoms/newIssue';
+import React from 'react';
 
 function TextBox() {
   const [isInputtedTitle, setIsInputtedTitle] =
-    useRecoilState(isInputtedTitleState);
+    useRecoilState(isInputtedTitleAtom);
+  const isClickedCompleteBtn = useRecoilValue(isClickedCompleteBtnAtom);
+  const setNewIssueContents = useSetRecoilState(newIssueContentsAtom);
+  const [numOfChars, setNumOfChars] = useState(0);
+
+  const titleInput = useRef<HTMLInputElement>(null);
+  const contentsInput = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (
+      isClickedCompleteBtn &&
+      titleInput.current != null &&
+      contentsInput.current != null
+    )
+      setNewIssueContents({
+        title: titleInput.current.value,
+        description: contentsInput.current.value,
+      });
+  }, [isClickedCompleteBtn]);
 
   const handleChangeTitle = (e: React.ChangeEvent) => {
     const target = e.target as HTMLInputElement;
@@ -19,15 +43,47 @@ function TextBox() {
       setIsInputtedTitle(false);
   };
 
+  const handleChangeTextArea = (e: React.ChangeEvent) => {
+    const target = e.target as HTMLInputElement;
+    const length = target.value.length;
+    if (numOfChars === length) return;
+    setNumOfChars(length);
+  };
+
+  // 아직 서버 구현이 안 돼있어 추후에 구현 예정
+  const handleChangeFile = (e: React.ChangeEvent) => {
+    const target = e.target as HTMLInputElement;
+    const fileList = target.files;
+    if (fileList == null) return;
+    const formData = new FormData();
+    formData.append('file', fileList[0]);
+  };
+
   return (
     <TextBoxWrap>
-      <Input {...titleInput} onChange={handleChangeTitle} />
+      <Input
+        {...titleInputStyle}
+        ref={titleInput}
+        onChange={handleChangeTitle}
+      />
       <Description>
-        <Textarea {...contentsInput} />
-        <Span>띄어쓰기 포함 \d\d 자</Span>
+        <Textarea
+          {...contentsInputStyle}
+          ref={contentsInput}
+          onChange={handleChangeTextArea}
+        />
+        <Span>띄어쓰기 포함 {numOfChars} 자</Span>
         <ImageUploadWrap>
-          <FileIcon />
-          <span>파일 첨부하기</span>
+          <label htmlFor="input_file">
+            <FileIcon />
+            <span>파일 첨부하기</span>
+          </label>
+          <input
+            type="file"
+            accept="image/*"
+            id="input_file"
+            onChange={handleChangeFile}
+          />
         </ImageUploadWrap>
       </Description>
     </TextBoxWrap>
@@ -59,14 +115,30 @@ const Span = styled.div`
 const ImageUploadWrap = styled.div`
   display: flex;
   align-items: center;
-  padding: 16px 24px;
   height: 52px;
   color: ${({ theme }) => theme.colors.label};
   font-weight: ${({ theme }) => theme.fontWeights.bold};
   border-top: 1px dotted ${({ theme }) => theme.colors.gr_line};
-  cursor: pointer;
 
-  span {
-    padding-left: 10px;
+  label {
+    padding: 16px 24px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+
+    span {
+      padding-left: 10px;
+    }
+  }
+
+  input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    border: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
   }
 `;

--- a/FE/issue-tracker/src/components/newIssue/TextBox.tsx
+++ b/FE/issue-tracker/src/components/newIssue/TextBox.tsx
@@ -1,55 +1,11 @@
-import { useState, useEffect, useRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-
-import { Input } from '@chakra-ui/input';
-import { Textarea } from '@chakra-ui/textarea';
 
 import { ReactComponent as FileIcon } from '@assets/file.svg';
-import { contentsInputStyle, titleInputStyle } from './style';
-import {
-  isInputtedTitleAtom,
-  isClickedCompleteBtnAtom,
-  newIssueContentsAtom,
-} from '@store/atoms/newIssue';
-import React from 'react';
+import TitleInput from './TitleInput';
+import ContentsTextArea from './ContentsTextArea';
 
 function TextBox() {
-  const [isInputtedTitle, setIsInputtedTitle] =
-    useRecoilState(isInputtedTitleAtom);
-  const isClickedCompleteBtn = useRecoilValue(isClickedCompleteBtnAtom);
-  const setNewIssueContents = useSetRecoilState(newIssueContentsAtom);
-  const [numOfChars, setNumOfChars] = useState(0);
-
-  const titleInput = useRef<HTMLInputElement>(null);
-  const contentsInput = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    if (
-      isClickedCompleteBtn &&
-      titleInput.current != null &&
-      contentsInput.current != null
-    )
-      setNewIssueContents({
-        title: titleInput.current.value,
-        description: contentsInput.current.value,
-      });
-  }, [isClickedCompleteBtn]);
-
-  const handleChangeTitle = (e: React.ChangeEvent) => {
-    const target = e.target as HTMLInputElement;
-    if (!isInputtedTitle && target.value.length > 0) setIsInputtedTitle(true);
-    else if (isInputtedTitle && target.value.length === 0)
-      setIsInputtedTitle(false);
-  };
-
-  const handleChangeTextArea = (e: React.ChangeEvent) => {
-    const target = e.target as HTMLInputElement;
-    const length = target.value.length;
-    if (numOfChars === length) return;
-    setNumOfChars(length);
-  };
-
   // 아직 서버 구현이 안 돼있어 추후에 구현 예정
   const handleChangeFile = (e: React.ChangeEvent) => {
     const target = e.target as HTMLInputElement;
@@ -61,18 +17,9 @@ function TextBox() {
 
   return (
     <TextBoxWrap>
-      <Input
-        {...titleInputStyle}
-        ref={titleInput}
-        onChange={handleChangeTitle}
-      />
+      <TitleInput />
       <Description>
-        <Textarea
-          {...contentsInputStyle}
-          ref={contentsInput}
-          onChange={handleChangeTextArea}
-        />
-        <Span>띄어쓰기 포함 {numOfChars} 자</Span>
+        <ContentsTextArea />
         <ImageUploadWrap>
           <label htmlFor="input_file">
             <FileIcon />
@@ -101,15 +48,6 @@ const Description = styled.div`
   position: relative;
   background: ${({ theme }) => theme.colors.gr_inputBackground};
   border-radius: ${({ theme }) => theme.radii['2xl']};
-`;
-
-const Span = styled.div`
-  right: 30px;
-  bottom: 72px;
-  font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-weight: ${({ theme }) => theme.fontWeights.medium};
-  color: ${({ theme }) => theme.colors.label};
-  position: absolute;
 `;
 
 const ImageUploadWrap = styled.div`

--- a/FE/issue-tracker/src/components/newIssue/TitleInput.tsx
+++ b/FE/issue-tracker/src/components/newIssue/TitleInput.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+import { Input } from '@chakra-ui/input';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import {
+  isInputtedTitleAtom,
+  isClickedCompleteBtnAtom,
+  newIssueContentsAtom,
+} from '@store/atoms/newIssue';
+import { titleInputStyle } from './style';
+
+function TitleInput() {
+  const [isInputtedTitle, setIsInputtedTitle] =
+    useRecoilState(isInputtedTitleAtom);
+  const isClickedCompleteBtn = useRecoilValue(isClickedCompleteBtnAtom);
+  const [newIssueContents, setNewIssueContents] =
+    useRecoilState(newIssueContentsAtom);
+  const titleInput = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isClickedCompleteBtn && titleInput.current != null)
+      setNewIssueContents({
+        ...newIssueContents,
+        title: titleInput.current.value,
+      });
+  }, [isClickedCompleteBtn]);
+
+  const handleChangeTitle = (e: React.ChangeEvent) => {
+    const target = e.target as HTMLInputElement;
+    if (!isInputtedTitle && target.value.length > 0) setIsInputtedTitle(true);
+    else if (isInputtedTitle && target.value.length === 0)
+      setIsInputtedTitle(false);
+  };
+
+  return (
+    <>
+      <Input
+        {...titleInputStyle}
+        ref={titleInput}
+        onChange={handleChangeTitle}
+      />
+    </>
+  );
+}
+
+export default TitleInput;

--- a/FE/issue-tracker/src/components/newIssue/select/AssigneeModal.tsx
+++ b/FE/issue-tracker/src/components/newIssue/select/AssigneeModal.tsx
@@ -5,38 +5,28 @@ import { Avatar } from '@chakra-ui/avatar';
 import MenuTitle from '@components/common/MenuTitle';
 import { checkBoxStyle, menuItemStyle } from '@styles/chakraStyle';
 import { modalStyle } from '../style';
-import {
-  assigneeType,
-  checkedAssigneesState,
-} from '@store/atoms/checkedThings';
+import { assigneeType, checkedAssigneesAtom } from '@store/atoms/checkedThings';
 
 type Props = {
-  assignees: { user_id: number; name: string; avatar_url: string }[] | null;
+  assignees: assigneeType[] | null;
   errorMsg: string;
 };
 
 function AssigneeModal({ assignees, errorMsg }: Props) {
-  const [checkedAssignees, setCheckedAssignees] = useRecoilState<
-    assigneeType[]
-  >(checkedAssigneesState);
+  const [checkedAssignees, setCheckedAssignees] =
+    useRecoilState(checkedAssigneesAtom);
   const modalTitle = errorMsg == 'No Error' ? '담당자 추가' : errorMsg;
 
   const handleClickMenuItem = (e: React.MouseEvent) => {
     const target = e.target as HTMLInputElement;
     const itemEl = target.closest('.checkbox') as HTMLInputElement;
-    const itemId = itemEl.dataset.id;
+    const itemId = Number(itemEl.dataset.id);
     if (target.tagName !== 'INPUT' || assignees == null || itemId == null)
       return;
 
-    const clickedItem = assignees.find((item) => item.user_id === +itemId);
-    if (clickedItem == null) return;
-    const isChecked = checkedAssignees.includes(clickedItem) ? false : true;
-
-    if (isChecked) setCheckedAssignees([...checkedAssignees, clickedItem]);
-    else
-      setCheckedAssignees(
-        checkedAssignees.filter((item) => item.user_id !== clickedItem.user_id)
-      );
+    const isChecked = checkedAssignees.includes(itemId) ? false : true;
+    if (isChecked) setCheckedAssignees([...checkedAssignees, itemId]);
+    else setCheckedAssignees(checkedAssignees.filter((id) => id !== itemId));
   };
 
   return (

--- a/FE/issue-tracker/src/components/newIssue/select/LabelModal.tsx
+++ b/FE/issue-tracker/src/components/newIssue/select/LabelModal.tsx
@@ -5,7 +5,7 @@ import Label from '@components/common/Label';
 import MenuTitle from '@components/common/MenuTitle';
 import { checkBoxStyle, menuItemStyle } from '@styles/chakraStyle';
 import { modalStyle } from '../style';
-import { labelType, checkedLabelsState } from '@store/atoms/checkedThings';
+import { labelType, checkedLabelsAtom } from '@store/atoms/checkedThings';
 
 type Props = {
   labels: labelType[] | null;
@@ -13,24 +13,18 @@ type Props = {
 };
 
 function LabelModal({ labels, errorMsg }: Props) {
-  const [checkedLabels, setCheckedLabels] = useRecoilState(checkedLabelsState);
+  const [checkedLabels, setCheckedLabels] = useRecoilState(checkedLabelsAtom);
   const modalTitle = errorMsg == 'No Error' ? '레이블 추가' : errorMsg;
 
   const handleClickMenuItem = (e: React.MouseEvent) => {
     const target = e.target as HTMLInputElement;
     const itemEl = target.closest('.checkbox') as HTMLInputElement;
-    const itemId = itemEl.dataset.id;
+    const itemId = Number(itemEl.dataset.id);
     if (target.tagName !== 'INPUT' || labels == null || itemId == null) return;
 
-    const clickedItem = labels.find((label) => label.id === +itemId);
-    if (clickedItem == null) return;
-    const isChecked = checkedLabels.includes(clickedItem) ? false : true;
-
-    if (isChecked) setCheckedLabels([...checkedLabels, clickedItem]);
-    else
-      setCheckedLabels(
-        checkedLabels.filter((label) => label.id !== clickedItem.id)
-      );
+    const isChecked = checkedLabels.includes(itemId) ? false : true;
+    if (isChecked) setCheckedLabels([...checkedLabels, itemId]);
+    else setCheckedLabels(checkedLabels.filter((id) => id !== itemId));
   };
 
   return (

--- a/FE/issue-tracker/src/components/newIssue/select/MilestoneModal.tsx
+++ b/FE/issue-tracker/src/components/newIssue/select/MilestoneModal.tsx
@@ -6,7 +6,7 @@ import MenuTitle from '@components/common/MenuTitle';
 import { checkBoxStyle } from '@styles/chakraStyle';
 import {
   milestoneType,
-  checkedMilestoneState,
+  checkedMilestoneAtom,
 } from '@store/atoms/checkedThings';
 
 type Props = {
@@ -15,9 +15,8 @@ type Props = {
 };
 
 function MilestoneModal({ milestones, errorMsg }: Props) {
-  const [checkedMilestones, setCheckedMilestones] = useRecoilState(
-    checkedMilestoneState
-  );
+  const [checkedMilestones, setCheckedMilestones] =
+    useRecoilState(checkedMilestoneAtom);
   const modalTitle = errorMsg == 'No Error' ? '마일스톤 추가' : errorMsg;
 
   const handleClickMenuItem = (e: React.MouseEvent) => {

--- a/FE/issue-tracker/src/components/newIssue/select/SelectAssignee.tsx
+++ b/FE/issue-tracker/src/components/newIssue/select/SelectAssignee.tsx
@@ -8,12 +8,17 @@ import { ReactComponent as PlusIcon } from '@assets/plus.svg';
 import { menuBtnStyle } from '@styles/chakraStyle';
 import AssigneeModal from './AssigneeModal';
 import { fetchModal } from '@utils/fetchModal';
-import { checkedAssigneesState } from '@store/atoms/checkedThings';
+import { assigneeType, checkedAssigneesAtom } from '@store/atoms/checkedThings';
 
 function SelectAssignee() {
-  const [assignees, setAssignees] = useState(null);
+  const [assignees, setAssignees] = useState<assigneeType[] | null>(null);
   const [errorMsg, setErrorMsg] = useState('No Error');
-  const checkedAssignees = useRecoilValue(checkedAssigneesState);
+  const checkedAssignees = useRecoilValue(checkedAssigneesAtom);
+
+  const checkedAssigneesInfo = checkedAssignees.map((id) => {
+    if (assignees !== null)
+      return assignees.find((assignee) => assignee.user_id === id);
+  }) as assigneeType[];
 
   const handleClickAssignee = () => {
     fetchModal({
@@ -39,14 +44,15 @@ function SelectAssignee() {
         <AssigneeModal assignees={assignees} errorMsg={errorMsg} />
       </Menu>
       <AddList>
-        {checkedAssignees.map(({ user_id, name, avatar_url }) => {
-          return (
-            <li key={user_id}>
-              <Avatar size="sm" src={avatar_url} />
-              <Text>{name}</Text>
-            </li>
-          );
-        })}
+        {checkedAssigneesInfo &&
+          checkedAssigneesInfo.map(({ user_id, name, avatar_url }) => {
+            return (
+              <li key={user_id}>
+                <Avatar size="sm" src={avatar_url} />
+                <Text>{name}</Text>
+              </li>
+            );
+          })}
       </AddList>
     </Wrap>
   );

--- a/FE/issue-tracker/src/components/newIssue/select/SelectLabel.tsx
+++ b/FE/issue-tracker/src/components/newIssue/select/SelectLabel.tsx
@@ -8,12 +8,16 @@ import Label from '@components/common/Label';
 import { menuBtnStyle } from '@styles/chakraStyle';
 import LabelModal from './LabelModal';
 import { fetchModal } from '@utils/fetchModal';
-import { checkedLabelsState } from '@store/atoms/checkedThings';
+import { labelType, checkedLabelsAtom } from '@store/atoms/checkedThings';
 
 function SelectLabel() {
-  const [labels, setLabels] = useState(null);
+  const [labels, setLabels] = useState<labelType[] | null>(null);
   const [errorMsg, setErrorMsg] = useState('No Error');
-  const checkedLabels = useRecoilValue(checkedLabelsState);
+  const checkedLabels = useRecoilValue(checkedLabelsAtom);
+
+  const checkedLabelsInfo = checkedLabels.map((id) => {
+    if (labels !== null) return labels.find((label) => label.id === id);
+  }) as labelType[];
 
   const handleClickLabels = () => {
     fetchModal({
@@ -39,17 +43,18 @@ function SelectLabel() {
         <LabelModal labels={labels} errorMsg={errorMsg} />
       </Menu>
       <AddList>
-        {checkedLabels.map(({ title, color_code, font_light }) => {
-          return (
-            <li key={title}>
-              <Label
-                name={title}
-                colorCode={color_code}
-                fontLight={font_light}
-              />
-            </li>
-          );
-        })}
+        {checkedLabelsInfo &&
+          checkedLabelsInfo.map(({ title, color_code, font_light }) => {
+            return (
+              <li key={title}>
+                <Label
+                  name={title}
+                  colorCode={color_code}
+                  fontLight={font_light}
+                />
+              </li>
+            );
+          })}
       </AddList>
     </Wrap>
   );

--- a/FE/issue-tracker/src/components/newIssue/select/SelectMilestone.tsx
+++ b/FE/issue-tracker/src/components/newIssue/select/SelectMilestone.tsx
@@ -8,7 +8,7 @@ import { menuBtnStyle } from '@styles/chakraStyle';
 import { progressBar } from '../style';
 import MilestoneModal from './MilestoneModal';
 import { fetchModal } from '@utils/fetchModal';
-import { checkedMilestoneState } from '@store/atoms/checkedThings';
+import { checkedMilestoneAtom } from '@store/atoms/checkedThings';
 
 type progressValueType = {
   progress: number;
@@ -18,7 +18,7 @@ type progressValueType = {
 function SelectMilestone() {
   const [milestones, setMilestones] = useState(null);
   const [errorMsg, setErrorMsg] = useState('No Error');
-  const checkedMilestones = useRecoilValue(checkedMilestoneState);
+  const checkedMilestones = useRecoilValue(checkedMilestoneAtom);
   const [progressValue, setProgressValue] =
     useState<progressValueType | null>(null);
 

--- a/FE/issue-tracker/src/components/newIssue/style.ts
+++ b/FE/issue-tracker/src/components/newIssue/style.ts
@@ -1,6 +1,6 @@
 import theme from '@styles/theme.js';
 
-const titleInput = {
+const titleInputStyle = {
   marginBottom: '16px',
   padding: '16px',
   height: '56px',
@@ -10,7 +10,7 @@ const titleInput = {
   borderRadius: '14px',
 };
 
-const contentsInput = {
+const contentsInputStyle = {
   size: 'md',
   height: '291px',
   padding: '16px 24px',
@@ -43,8 +43,8 @@ const modalListStyle = {
 };
 
 export {
-  titleInput,
-  contentsInput,
+  titleInputStyle,
+  contentsInputStyle,
   progressBar,
   modalStyle,
   modalTitleStyle,

--- a/FE/issue-tracker/src/pages/NewIssue.tsx
+++ b/FE/issue-tracker/src/pages/NewIssue.tsx
@@ -1,8 +1,19 @@
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 import Header from '@components/common/Header';
 import NewIssueContainer from '@components/newIssue/NewIssueContainer';
 import styled from 'styled-components';
+import { isClickedCompleteBtnAtom } from '@store/atoms/newIssue';
 
 function NewIssue() {
+  const [isClickedCompleteBtn, setIsClickedCompleteBtn] = useRecoilState(
+    isClickedCompleteBtnAtom
+  );
+
+  useEffect(() => {
+    if (isClickedCompleteBtn) setIsClickedCompleteBtn(false);
+  }, []);
+
   return (
     <NewIssueWrap>
       <Header />

--- a/FE/issue-tracker/src/store/atoms/checkedThings.ts
+++ b/FE/issue-tracker/src/store/atoms/checkedThings.ts
@@ -23,17 +23,17 @@ export type milestoneType = {
   closed_issue_count: number;
 };
 
-export const checkedAssigneesState = atom<assigneeType[]>({
+export const checkedAssigneesAtom = atom<number[]>({
   key: 'checkedAssignees',
   default: [],
 });
 
-export const checkedLabelsState = atom<labelType[]>({
+export const checkedLabelsAtom = atom<number[]>({
   key: 'checkedLabels',
   default: [],
 });
 
-export const checkedMilestoneState = atom<milestoneType | null>({
+export const checkedMilestoneAtom = atom<milestoneType | null>({
   key: 'checkedMilestone',
   default: null,
 });

--- a/FE/issue-tracker/src/store/atoms/newIssue.ts
+++ b/FE/issue-tracker/src/store/atoms/newIssue.ts
@@ -1,6 +1,19 @@
 import { atom } from 'recoil';
 
-export const isInputtedTitleState = atom({
+export const isInputtedTitleAtom = atom({
   key: 'isInputtedTitleState',
   default: false,
+});
+
+export const isClickedCompleteBtnAtom = atom({
+  key: 'isClickedCompleteBtnState',
+  default: false,
+});
+
+export const newIssueContentsAtom = atom({
+  key: 'newIssueContentsState',
+  default: {
+    title: '',
+    description: '',
+  },
 });

--- a/FE/issue-tracker/src/store/selectors/newIssue.ts
+++ b/FE/issue-tracker/src/store/selectors/newIssue.ts
@@ -1,0 +1,23 @@
+import { selector } from 'recoil';
+import { newIssueContentsAtom } from '../atoms/newIssue';
+import {
+  checkedAssigneesAtom,
+  checkedLabelsAtom,
+  checkedMilestoneAtom,
+} from '../atoms/checkedThings';
+
+export const getNewIssueBody = selector({
+  key: 'getNewIssueBody',
+  get: ({ get }) => {
+    const header = {
+      method: 'POST',
+      body: JSON.stringify({
+        ...get(newIssueContentsAtom),
+        assignee: get(checkedAssigneesAtom)[0],
+        label_ids: get(checkedLabelsAtom),
+        milestone_id: get(checkedMilestoneAtom)?.id,
+      }),
+    };
+    return header;
+  },
+});

--- a/FE/issue-tracker/src/utils/fetchWithAuth.ts
+++ b/FE/issue-tracker/src/utils/fetchWithAuth.ts
@@ -8,9 +8,10 @@ export const fetchWithAuth = async (
   errorMsg: string,
   options = {}
 ) => {
-  const token = localStorage.getItem('oauth_login');
+  const token = localStorage.getItem('oauth_login_token');
   const requestHeader = {
     Authorization: `bearer ${token}`,
+    'Content-Type': 'application/json',
   };
   const optionWithHeaders = { ...options, headers: requestHeader };
   try {


### PR DESCRIPTION
### 📌 SelectBox 체크하는 로직 수정
- 체크된 아이템의 정보 객체를 저장하는 방식에서 체크된 아이템 id만 저장하도록.
- 이유: 이슈 생성 post 요청 시 id만 보내야 함 + 조금 더 간결

### 📌 이미지 파일 첨부
 - image 확장자만 선택할 수 있도록,
 - 파일을 선택하면(onChange) file 정보 콘솔에 출력까지만 
 - 전송은 아직 미완(api미완)

### 📌 완료 버튼 눌렀을 때 title, contents 내용 가져오는 로직
atom: `완료클릭(boolean)`, `이슈작성내용(title, description 객체)`
1. `완료클릭` true로 셋
2. `완료클릭` useEffect에 따라 `이슈작성내용` 담아서 셋
3. `이슈작성내용` useEffect에 따라 post 요청                                    
