### PR TITLE
[FE] 라벨, 마일스톤 조회, 추가 버튼 토글 기능

### DIFF
--- a/FE/issue-tracker/src/components/common/Header.tsx
+++ b/FE/issue-tracker/src/components/common/Header.tsx
@@ -4,12 +4,18 @@ import { Avatar } from '@chakra-ui/react';
 import { ReactComponent as LogotypeMedium } from '@assets/LogotypeMedium.svg';
 
 function Header() {
+  const loginInfo = localStorage.getItem('login_info');
+  let avatar_url = '';
+  if (loginInfo != null) {
+    avatar_url = JSON.parse(loginInfo).avatar_url;
+  }
+
   return (
     <HeaderContainer>
       <Link to="/issues">
         <LogotypeMedium className="logo" />
       </Link>
-      <Avatar size="md" src="./janmang.jpeg" />
+      <Avatar size="md" src={avatar_url} />
     </HeaderContainer>
   );
 }

--- a/FE/issue-tracker/src/components/labels/Actions.tsx
+++ b/FE/issue-tracker/src/components/labels/Actions.tsx
@@ -4,25 +4,47 @@ import { Button } from '@chakra-ui/react';
 
 interface Props {
   page: string;
+  isAddClicked: boolean;
+  setIsAddClicked: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-function Actions({ page }: Props) {
+function Actions({ page, isAddClicked, setIsAddClicked }: Props) {
+  const handleClickAdd = () => {
+    setIsAddClicked((boolean) => !boolean);
+  };
+
   return (
     <ActionsWrap>
       <Tabs page={page} />
-      <Button
-        width="120px"
-        fontSize="xs"
-        background="bl_initial"
-        colorScheme="blue"
-      >
-        + 추가
-      </Button>
+      {isAddClicked ? (
+        <Button {...whiteButton} onClick={handleClickAdd}>
+          닫기
+        </Button>
+      ) : (
+        <Button {...blueButton} onClick={handleClickAdd}>
+          + 추가
+        </Button>
+      )}
     </ActionsWrap>
   );
 }
 
 export default Actions;
+
+const whiteButton = {
+  width: '120px',
+  fontSize: 'xs',
+  background: 'white',
+  color: 'bl_initial',
+  border: '2px solid #007AFF',
+};
+
+const blueButton = {
+  width: '120px',
+  fontSize: 'xs',
+  background: 'bl_initial',
+  colorScheme: 'blue',
+};
 
 const ActionsWrap = styled.section`
   /* theme에 추가하기 */

--- a/FE/issue-tracker/src/components/labels/LabelInputBox.tsx
+++ b/FE/issue-tracker/src/components/labels/LabelInputBox.tsx
@@ -14,39 +14,44 @@ import {
   labelColorLeft,
   labelCheckbox,
 } from '@components/labels/newLabelStyle';
+import { labelInfoType } from './table/LabelCell';
 
-interface Props {
+type Props = {
+  labelInfo: labelInfoType;
   children: JSX.Element;
-}
+};
 
-function LabelInputBox({ children }: Props) {
-  const colorCode = '#EFF0F6';
+function LabelInputBox({ labelInfo, children }: Props) {
+  const { title, description, color_code, font_light } = labelInfo;
 
   return (
     <NewLabelContent>
       <LabelTagBox>
-        <Label name={'레이블 이름'} colorCode={colorCode} fontLight={false} />
+        <Label name={title} colorCode={color_code} fontLight={font_light} />
       </LabelTagBox>
 
       <LabelInputsWrap>
-        <Input {...labelNameInput} />
-        <Input {...labelDescInput} />
+        <Input {...labelNameInput} value={title} />
+        <Input {...labelDescInput} value={description} />
 
         <LabelColorInput>
           <InputGroup size="md" width="240px" marginRight="16px">
             <InputLeftAddon {...labelColorLeft} children="배경 색상" />
-            <Input value={colorCode} variant="filled" />
+            <Input value={color_code} variant="filled" />
             <InputRightAddon
               children={<Refresh className="icon_refresh" />}
               border="none"
             />
           </InputGroup>
+
           <InputGroup size="md" width="352px" variant="filled">
             <InputLeftAddon {...labelColorLeft} children="텍스트 색상" />
-            <Checkbox {...labelCheckbox} defaultIsChecked>
+            <Checkbox {...labelCheckbox} defaultIsChecked={!font_light}>
               어두운색
             </Checkbox>
-            <Checkbox {...labelCheckbox}>밝은색</Checkbox>
+            <Checkbox {...labelCheckbox} defaultIsChecked={font_light}>
+              밝은색
+            </Checkbox>
             <InputRightAddon border="none" />
           </InputGroup>
         </LabelColorInput>

--- a/FE/issue-tracker/src/components/labels/NewLabel.tsx
+++ b/FE/issue-tracker/src/components/labels/NewLabel.tsx
@@ -3,10 +3,17 @@ import LabelInputBox from '@components/labels/LabelInputBox';
 import CompleteBtn from '@components/common/CompleteBtn';
 
 function NewLabel() {
+  const labelInfo = {
+    title: '레이블 이름',
+    description: '',
+    color_code: '#cee1e2',
+    font_light: false,
+  };
+
   return (
     <NewLabelWrap>
       <h2>새로운 레이블 추가</h2>
-      <LabelInputBox>
+      <LabelInputBox labelInfo={labelInfo}>
         <CompleteBtn />
       </LabelInputBox>
     </NewLabelWrap>

--- a/FE/issue-tracker/src/components/labels/table/EditLabel.tsx
+++ b/FE/issue-tracker/src/components/labels/table/EditLabel.tsx
@@ -1,12 +1,18 @@
 import styled from 'styled-components';
+
 import LabelInputBox from '@components/labels/LabelInputBox';
 import EditCompleteBtn from '@components/common/EditCompleteBtn';
+import { labelInfoType } from './LabelCell';
 
-function EditLabel() {
+type Props = {
+  labelInfo: labelInfoType;
+};
+
+function EditLabel({ labelInfo }: Props) {
   return (
     <EditLabelWrap>
       <h2>레이블 편집</h2>
-      <LabelInputBox>
+      <LabelInputBox labelInfo={labelInfo}>
         <EditCompleteBtn />
       </LabelInputBox>
     </EditLabelWrap>

--- a/FE/issue-tracker/src/components/labels/table/ErrorLabel.tsx
+++ b/FE/issue-tracker/src/components/labels/table/ErrorLabel.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+type Props = {
+  children: string;
+};
+
+function ErrorLabel({ children }: Props) {
+  const [time, setTime] = useState(3000);
+  const text = `이 창은 ${time / 1000}초 후에 자동으로 사라집니다.`;
+
+  setTimeout(() => setTime(0), time);
+  return (
+    <ErrorWrap time={time}>
+      {children}
+      <span>{text}</span>
+    </ErrorWrap>
+  );
+}
+
+export default ErrorLabel;
+
+type seconds = {
+  time: number;
+};
+
+const ErrorWrap = styled.div<seconds>`
+  position: absolute;
+  display: ${({ time }) => (time ? 'flex' : 'none')};
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: #313030dc;
+  top: 50%;
+  left: 50%;
+  width: 50%;
+  height: 200px;
+  transform: translate3d(-50%, -50%, 0);
+  color: ${({ theme }) => theme.colors.gr_offWhite};
+  font-size: ${({ theme }) => theme.fontSizes.xl};
+  border-radius: 16px;
+
+  span {
+    font-size: ${({ theme }) => theme.fontSizes.xs};
+  }
+`;

--- a/FE/issue-tracker/src/components/labels/table/LabelCell.tsx
+++ b/FE/issue-tracker/src/components/labels/table/LabelCell.tsx
@@ -2,38 +2,59 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import Label from '@components/common/Label';
+import EditLabel from './EditLabel';
 import EditMiniButton from '@components/common/EditMiniButton';
 import DeleteMiniButton from '@components/common/DeleteMiniButton';
 
-interface Props {
-  isLastItemStyle: boolean;
-}
+export type labelInfoType = {
+  id?: number;
+  title: string;
+  description: string;
+  color_code: string;
+  font_light: boolean;
+};
 
-function LabelCell({ isLastItemStyle }: Props) {
-  const [isDisabled, setIsDisabled] = useState(true);
+type Props = {
+  labelInfo: labelInfoType;
+  isLastItemStyle: boolean;
+};
+
+function LabelCell({ labelInfo, isLastItemStyle }: Props) {
+  const [isEditClicked, setIsEditClicked] = useState<boolean>(false);
+  const { title, description, color_code, font_light } = labelInfo;
 
   return (
-    <LabelWrap isLastItemStyle={isLastItemStyle}>
-      <StyledDiv>
-        <LabelBox>
-          <Label name="documentation" colorCode="#004DE3" fontLight={true} />
-        </LabelBox>
-        <LabelDescript>레이블에 대한 설명</LabelDescript>
-      </StyledDiv>
+    <>
+      {isEditClicked ? (
+        <EditLabel labelInfo={labelInfo} />
+      ) : (
+        <LabelWrap isLastItemStyle={isLastItemStyle}>
+          <StyledDiv>
+            <LabelBox>
+              <Label
+                name={title}
+                colorCode={color_code}
+                fontLight={font_light}
+              />
+            </LabelBox>
+            <LabelDescript>{description}</LabelDescript>
+          </StyledDiv>
 
-      <LabelButtons>
-        <EditMiniButton setState={setIsDisabled}>편집</EditMiniButton>
-        <DeleteMiniButton>삭제</DeleteMiniButton>
-      </LabelButtons>
-    </LabelWrap>
+          <LabelButtons>
+            <EditMiniButton setState={setIsEditClicked}>편집</EditMiniButton>
+            <DeleteMiniButton>삭제</DeleteMiniButton>
+          </LabelButtons>
+        </LabelWrap>
+      )}
+    </>
   );
 }
 
 export default LabelCell;
 
-interface LabelWrapType {
+type LabelWrapType = {
   isLastItemStyle: boolean;
-}
+};
 
 const LabelWrap = styled.div<LabelWrapType>`
   ${({ theme }) => theme.cellWrap};

--- a/FE/issue-tracker/src/components/labels/table/LabelCellSkeleton.tsx
+++ b/FE/issue-tracker/src/components/labels/table/LabelCellSkeleton.tsx
@@ -1,0 +1,55 @@
+import styled from 'styled-components';
+import { Skeleton } from '@chakra-ui/skeleton';
+
+type Props = {
+  labelWidth: string;
+  descWidth: string;
+};
+
+function LabelCellSkeleton({ labelWidth, descWidth }: Props) {
+  return (
+    <LabelWrap>
+      <StyledDiv>
+        <LabelBox>
+          <Skeleton height="20px" width={labelWidth} borderRadius="16px" />
+        </LabelBox>
+        <LabelDescript>
+          <Skeleton height="20px" width={descWidth} borderRadius="5px" />
+        </LabelDescript>
+      </StyledDiv>
+      <LabelButtons>
+        <div>
+          <Skeleton height="25px" width="55px" borderRadius="5px" />
+        </div>
+        <div>
+          <Skeleton height="25px" width="55px" borderRadius="5px" />
+        </div>
+      </LabelButtons>
+    </LabelWrap>
+  );
+}
+
+export default LabelCellSkeleton;
+
+const LabelWrap = styled.div`
+  ${({ theme }) => theme.cellWrap};
+`;
+
+const StyledDiv = styled.div`
+  display: flex;
+`;
+
+const LabelBox = styled.div`
+  width: 208px;
+`;
+
+const LabelDescript = styled.div`
+  width: 800px;
+  color: ${({ theme }) => theme.colors.gr_label};
+`;
+
+const LabelButtons = styled.div`
+  width: 140px;
+  display: flex;
+  justify-content: space-between;
+`;

--- a/FE/issue-tracker/src/components/labels/table/LabelTable.tsx
+++ b/FE/issue-tracker/src/components/labels/table/LabelTable.tsx
@@ -1,15 +1,37 @@
 import styled from 'styled-components';
-import TableHeader from '@components/labels/table/TableHeader';
-import LabelCell from '@components/labels/table/LabelCell';
-import EditLabel from '@components/labels/table/EditLabel';
+import { useRecoilValueLoadable } from 'recoil';
+
+import { LabelOrMilestone } from '@store/selectors/LabelOrMilestone';
+import TableHeader from './TableHeader';
+import LabelCell, { labelInfoType } from './LabelCell';
+import ErrorLabel from './ErrorLabel';
+import NoLabel from './NoLabel';
+import LabelsSkeleton from './LabelsSkeleton';
 
 function LabelTable() {
+  const { state, contents } = useRecoilValueLoadable(
+    LabelOrMilestone('labels')
+  );
+  const noLabel = typeof contents === 'string' || contents.length === 0;
+  const isLastItem = (idx: number) => idx === contents.length - 1;
+
   return (
     <LabelTableWrap>
       <TableHeader />
-      <LabelCell isLastItemStyle={false} />
-      <EditLabel />
-      <LabelCell isLastItemStyle={true} />
+      {state === 'loading' && <LabelsSkeleton />}
+      {state === 'hasError' && <ErrorLabel>{contents}</ErrorLabel>}
+      {state === 'hasValue' &&
+        contents.map((labelInfo: labelInfoType, i: number) => {
+          return (
+            <LabelCell
+              key={labelInfo.id}
+              labelInfo={labelInfo}
+              isLastItemStyle={isLastItem(i)}
+            />
+          );
+        })}
+
+      {noLabel && <NoLabel />}
     </LabelTableWrap>
   );
 }

--- a/FE/issue-tracker/src/components/labels/table/LabelsSkeleton.tsx
+++ b/FE/issue-tracker/src/components/labels/table/LabelsSkeleton.tsx
@@ -1,0 +1,17 @@
+import LabelCellSkeleton from './LabelCellSkeleton';
+
+function LabelsSkeleton() {
+  return (
+    <>
+      <LabelCellSkeleton labelWidth="90px" descWidth="280px" />
+      <LabelCellSkeleton labelWidth="110px" descWidth="430px" />
+      <LabelCellSkeleton labelWidth="90px" descWidth="330px" />
+      <LabelCellSkeleton labelWidth="70px" descWidth="270px" />
+      <LabelCellSkeleton labelWidth="80px" descWidth="320px" />
+      <LabelCellSkeleton labelWidth="90px" descWidth="460px" />
+      <LabelCellSkeleton labelWidth="110px" descWidth="300px" />
+    </>
+  );
+}
+
+export default LabelsSkeleton;

--- a/FE/issue-tracker/src/components/labels/table/NoLabel.tsx
+++ b/FE/issue-tracker/src/components/labels/table/NoLabel.tsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+import { noLabelMsg } from '@const/var';
+
+function NoLabel() {
+  return (
+    <NoLabelWrap>
+      <span>{noLabelMsg}</span>
+    </NoLabelWrap>
+  );
+}
+
+export default NoLabel;
+
+const NoLabelWrap = styled.div`
+  height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: ${({ theme }) => theme.colors.gr_offWhite};
+`;

--- a/FE/issue-tracker/src/components/milestones/table/MilestoneCell.tsx
+++ b/FE/issue-tracker/src/components/milestones/table/MilestoneCell.tsx
@@ -7,13 +7,27 @@ import DeleteMiniButton from '@components/common/DeleteMiniButton';
 import CloseMiniButton from '@components/common/CloseMiniButton';
 import { useState } from 'react';
 
-interface Props {
-  isLastItemStyle: boolean;
-}
+export type milestoneType = {
+  id: number;
+  title: string;
+  description: string;
+  closed: boolean;
+  due_date: string;
+  opened_issue_count: number;
+  closed_issue_count: number;
+};
 
-function MilestoneCell({ isLastItemStyle }: Props) {
+type Props = {
+  milestone: milestoneType;
+  isLastItemStyle: boolean;
+};
+
+function MilestoneCell({ milestone, isLastItemStyle }: Props) {
   const [isDisabled, setIsDisabled] = useState(true);
-  let progressValue = 80;
+  const { title, description, due_date } = milestone;
+  const opened = milestone.opened_issue_count;
+  const closed = milestone.closed_issue_count;
+  const progressValue = (closed * 100) / (opened + closed);
 
   return (
     <MilestoneWrap isLastItemStyle={isLastItemStyle}>
@@ -22,15 +36,15 @@ function MilestoneCell({ isLastItemStyle }: Props) {
         <TitleBox>
           <MilestoneTitle>
             <MilestoneIcon className="icon milestone_icon" />
-            마일스톤 제목
+            {title}
           </MilestoneTitle>
           <MilestoneDate>
             <CalendarIcon className="icon calendar_icon" />
-            완료일 일정
+            {due_date}
           </MilestoneDate>
         </TitleBox>
 
-        <MilestoneDesc>마일스톤에 대한 설명</MilestoneDesc>
+        <MilestoneDesc>{description}</MilestoneDesc>
       </MilestoneLeft>
 
       {/* 마일스톤 오른쪽 */}
@@ -52,8 +66,8 @@ function MilestoneCell({ isLastItemStyle }: Props) {
         <ProgressInfo>
           <PercentInfo>{progressValue}%</PercentInfo>
           <IssueInfo>
-            <NumOfOpenIssue>열린 이슈 {1}</NumOfOpenIssue>
-            <NumOfCloseIssue>닫힌 이슈 {2}</NumOfCloseIssue>
+            <NumOfOpenIssue>열린 이슈 {opened}</NumOfOpenIssue>
+            <NumOfCloseIssue>닫힌 이슈 {closed}</NumOfCloseIssue>
           </IssueInfo>
         </ProgressInfo>
       </MilestoneRight>

--- a/FE/issue-tracker/src/components/milestones/table/MilestoneTable.tsx
+++ b/FE/issue-tracker/src/components/milestones/table/MilestoneTable.tsx
@@ -1,15 +1,36 @@
 import styled from 'styled-components';
-import TableHeader from '@components/milestones/table/TableHeader';
-import MilestoneCell from '@components/milestones/table/MilestoneCell';
-import EditMilestone from '@components/milestones/table/EditMilestone';
+import { useRecoilValueLoadable } from 'recoil';
+
+import { LabelOrMilestone } from '@store/selectors/LabelOrMilestone';
+import TableHeader from './TableHeader';
+import MilestoneCell from './MilestoneCell';
+import EditMilestone from './EditMilestone';
+import { milestoneType } from './MilestoneCell';
+import LabelsSkeleton from '@components/labels/table/LabelsSkeleton';
 
 function MilestoneTable() {
+  const { state, contents } = useRecoilValueLoadable(
+    LabelOrMilestone('milestones')
+  );
+  const isLastItem = (idx: number) => idx === contents.length - 1;
+
   return (
     <MilestoneTableWrap>
       <TableHeader />
-      <MilestoneCell isLastItemStyle={false} />
-      <EditMilestone />
-      <MilestoneCell isLastItemStyle={true} />
+      {state === 'loading' && <LabelsSkeleton />}
+      {/* {state === 'hasError' && <ErrorLabel>{contents}</ErrorLabel>} */}
+      {state === 'hasValue' &&
+        contents.map((milestone: milestoneType, i: number) => {
+          return (
+            <MilestoneCell
+              key={milestone.id}
+              milestone={milestone}
+              isLastItemStyle={isLastItem(i)}
+            />
+          );
+        })}
+
+      {false && <EditMilestone />}
     </MilestoneTableWrap>
   );
 }

--- a/FE/issue-tracker/src/const/var.ts
+++ b/FE/issue-tracker/src/const/var.ts
@@ -3,6 +3,11 @@ export const hostAPI = process.env.REACT_APP_API;
 export const urlErrorMsg = '요청하신 주소에 문제가 있습니다.';
 export const issueListErrorMsg = '이슈 목록을 불러오는 데 실패했습니다.';
 
+export const labelErrorMsg = '라벨 목록을 불러오는 데 실패했습니다.';
+export const noLabelMsg = '등록된 레이블이 없습니다.';
+
+export const milestoneErrorMsg = '마일스톤 목록을 불러오는 데 실패했습니다.';
+
 const clientID = process.env.REACT_APP_CLIENT_ID;
 
 export const baseURL = 'http://15.164.68.136/api';

--- a/FE/issue-tracker/src/pages/Labels.tsx
+++ b/FE/issue-tracker/src/pages/Labels.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import Header from '@components/common/Header';
 import Actions from '@components/labels/Actions';
@@ -5,11 +6,17 @@ import NewLabel from '@components/labels/NewLabel';
 import LabelTable from '@components/labels/table/LabelTable';
 
 function Labels() {
+  const [isAddClicked, setIsAddClicked] = useState(false);
+
   return (
     <LabelsPageContainer>
       <Header />
-      <Actions page="labels" />
-      <NewLabel />
+      <Actions
+        page="labels"
+        isAddClicked={isAddClicked}
+        setIsAddClicked={setIsAddClicked}
+      />
+      {isAddClicked && <NewLabel />}
       <LabelTable />
     </LabelsPageContainer>
   );

--- a/FE/issue-tracker/src/pages/Milestones.tsx
+++ b/FE/issue-tracker/src/pages/Milestones.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import Header from '@components/common/Header';
 import Actions from '@components/labels/Actions';
@@ -5,11 +6,17 @@ import NewMilestone from '@components/milestones/NewMilestone';
 import MilestoneTable from '@components/milestones/table/MilestoneTable';
 
 function Milestones() {
+  const [isAddClicked, setIsAddClicked] = useState(false);
+
   return (
     <MilestonesPageContainer>
       <Header />
-      <Actions page="milestones" />
-      <NewMilestone />
+      <Actions
+        page="milestones"
+        isAddClicked={isAddClicked}
+        setIsAddClicked={setIsAddClicked}
+      />
+      {isAddClicked && <NewMilestone />}
       <MilestoneTable />
     </MilestonesPageContainer>
   );

--- a/FE/issue-tracker/src/store/selectors/LabelOrMilestone.ts
+++ b/FE/issue-tracker/src/store/selectors/LabelOrMilestone.ts
@@ -1,0 +1,19 @@
+import { selectorFamily } from 'recoil';
+import { baseURL } from '@const/var';
+import { fetchWithAuth } from '@utils/fetchWithAuth';
+import { urlErrorMsg, labelErrorMsg } from '@const/var';
+
+export const LabelOrMilestone = selectorFamily({
+  key: 'LabelOrMilestone',
+  get: (path: string) => async () => {
+    try {
+      const url = `${baseURL}/${path}`;
+      const res = await fetchWithAuth(url, labelErrorMsg);
+      const jsonData = res.json();
+      return jsonData;
+    } catch (error) {
+      if (typeof error === 'object') throw urlErrorMsg;
+      throw error;
+    }
+  },
+});


### PR DESCRIPTION
## 구현 기능
- 라벨, 마일스톤 페이지 조회
- 라벨 요청 시 state에 따라 loading, error, labels 컴포넌트 렌더링
- 마일스톤은 위 작업 아직 진행 중
- 라벨, 마일스톤 페이지에서 추가 버튼 클릭 시 newLabel, newMilestone 컴포넌트 토글 기능
- 라벨, 마일스톤 페이지에서 편집 버튼 클릭 시 editLabel, editMilestone 컴포넌트 렌더링, (아직 닫기 기능은 안 돼있음)